### PR TITLE
Export decimal number patterns for all plural forms

### DIFF
--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -94,8 +94,15 @@ module Cldr
       end
 
       def locales(locale, component, options)
-        locale = locale.to_s.gsub('_', '-')
-        locales = options[:merge] ? I18n::Locale::Fallbacks.new[locale.to_sym] : [locale.to_sym]
+        locale = locale.to_s.gsub('_', '-').to_sym
+
+        locales = if options[:merge]
+          # passing locale itself into constructor as a default fallback to avoid falling back to :en locale
+          I18n::Locale::Fallbacks.new([locale])[locale]
+        else
+          [locale]
+        end
+
         locales << :root if component_should_merge_root?(component)
         locales
       end

--- a/lib/cldr/export/data/numbers.rb
+++ b/lib/cldr/export/data/numbers.rb
@@ -44,38 +44,60 @@ module Cldr
         end
 
         def format(type)
-          result = select("numbers/#{type}Formats/#{type}FormatLength/#{type}Format").inject({}) do |format_result, format_node|
-            format_key = format_node.parent.attribute('type')
-            format_result[format_key ? format_key.value : :default] = select(format_node, "pattern").inject({}) do |pattern_result, pattern_node|
-              pattern_key_node = pattern_node.attribute('type')
+          result = select("numbers/#{type}Formats/#{type}FormatLength").inject({}) do |format_result, format_length_node|
+            format_nodes = select(format_length_node, "#{type}Format")
 
-              pattern_count_node = pattern_node.attribute('count')
+            format_key = format_length_node.attribute('type')
+            format_key = format_key ? format_key.value : :default
 
-              unless draft?(pattern_node)
-                pattern_key = pattern_key_node ? pattern_key_node.value : :default
+            if format_nodes.size > 0
+              format_nodes.each do |format_node|
+                format_result[format_key] ||= select(format_node, "pattern").inject({}) do |pattern_result, pattern_node|
+                  pattern_key_node = pattern_node.attribute('type')
 
-                if pattern_count_node
-                  pattern_count = pattern_count_node.value
+                  pattern_count_node = pattern_node.attribute('count')
 
-                  if pattern_result[pattern_key].nil?
-                    pattern_result[pattern_key] ||= {}
-                  elsif !pattern_result[pattern_key].is_a?(Hash)
-                    raise "can't parse patterns with and without 'count' attribute in the same section"
+                  unless draft?(pattern_node)
+                    pattern_key = pattern_key_node ? pattern_key_node.value : :default
+
+                    if pattern_count_node
+                      pattern_count = pattern_count_node.value
+
+                      if pattern_result[pattern_key].nil?
+                        pattern_result[pattern_key] ||= {}
+                      elsif !pattern_result[pattern_key].is_a?(Hash)
+                        raise "can't parse patterns with and without 'count' attribute in the same section"
+                      end
+
+                      pattern_result[pattern_key][pattern_count] = pattern_node.content
+                    else
+                      pattern_result[pattern_key] = pattern_node.content
+                    end
                   end
 
-                  pattern_result[pattern_key][pattern_count] = pattern_node.content
-                else
-                  pattern_result[pattern_key] = pattern_node.content
+                  pattern_result
                 end
               end
+            else
+              aliased = select(format_length_node, 'alias').first
 
-              pattern_result
+              if aliased
+                format_result[format_key] = xpath_to_redirect(aliased.attribute('path').value)
+              end
             end
+
             format_result
           end
 
           result[:default] = result[:default][:default] if result[:default]
           result
+        end
+
+        def xpath_to_redirect(xpath)
+          length = xpath[/(\w+)FormatLength/, 1]
+          type   = xpath[/@type='(\w+)'/, 1]
+
+          :"numbers.formats.#{length}.patterns.#{type}"
         end
 
         def number_system(type)

--- a/test/export/data/numbers_test.rb
+++ b/test/export/data/numbers_test.rb
@@ -84,6 +84,11 @@ class TestCldrDataNumbers < Test::Unit::TestCase
     assert_equal expected, Cldr::Export::Data::Numbers.new('de')[:numbers][:formats]
   end
 
+  test "redirects in root locale" do
+    assert_equal :"numbers.formats.decimal.patterns.short",
+         Cldr::Export::Data::Numbers.new('root')[:numbers][:formats][:decimal][:patterns]['long']
+  end
+
   # Cldr::Export::Data.locales.each do |locale|
   #   test "extract number_symbols for #{locale}" do
   #     assert_nothing_raised do

--- a/test/export/data/numbers_test.rb
+++ b/test/export/data/numbers_test.rb
@@ -26,34 +26,36 @@ class TestCldrDataNumbers < Test::Unit::TestCase
         :number_system => "latn",
         :patterns => {
           :default => "#,##0.###",
-          "long" => {
-            "1000" => "0 Tausend",
-            "10000" => "00 Tausend",
-            "100000" => "000 Tausend",
-            "1000000" => "0 Millionen",
-            "10000000" => "00 Millionen",
-            "100000000" => "000 Millionen",
-            "1000000000" => "0 Milliarden",
-            "10000000000" => "00 Milliarden",
-            "100000000000" => "000 Milliarden",
-            "1000000000000" => "0 Billionen",
-            "10000000000000" => "00 Billionen",
-            "100000000000000" => "000 Billionen"
-          },
-          "short" => {
-            "1000" => "0 Tsd",
-            "10000" => "00 Tsd",
-            "100000" => "000 Tsd",
-            "1000000" => "0 Mio",
-            "10000000" => "00 Mio",
-            "100000000" => "000 Mio",
-            "1000000000" => "0 Mrd",
-            "10000000000" => "00 Mrd",
-            "100000000000" => "000 Mrd",
-            "1000000000000" => "0 Bio",
-            "10000000000000" => "00 Bio",
-            "100000000000000" => "000 Bio"
-          }
+          "long" =>
+            {
+              "1000"            => { "one" => "0 Tausend",      "other" => "0 Tausend" },
+              "10000"           => { "one" => "00 Tausend",     "other" => "00 Tausend" },
+              "100000"          => { "one" => "000 Tausend",    "other" => "000 Tausend" },
+              "1000000"         => { "one" => "0 Million",      "other" => "0 Millionen" },
+              "10000000"        => { "one" => "00 Millionen",   "other" => "00 Millionen" },
+              "100000000"       => { "one" => "000 Millionen",  "other" => "000 Millionen" },
+              "1000000000"      => { "one" => "0 Milliarde",    "other" => "0 Milliarden" },
+              "10000000000"     => { "one" => "00 Milliarden",  "other" => "00 Milliarden" },
+              "100000000000"    => { "one" => "000 Milliarden", "other" => "000 Milliarden" },
+              "1000000000000"   => { "one" => "0 Billion",      "other" => "0 Billionen" },
+              "10000000000000"  => { "one" => "00 Billionen",   "other" => "00 Billionen" },
+              "100000000000000" => { "one" => "000 Billionen",  "other" => "000 Billionen" }
+            },
+          "short" =>
+            {
+              "1000"            => { "one" => "0 Tsd",   "other" => "0 Tsd" },
+              "10000"           => { "one" => "00 Tsd",  "other" => "00 Tsd" },
+              "100000"          => { "one" => "000 Tsd", "other" => "000 Tsd" },
+              "1000000"         => { "one" => "0 Mio",   "other" => "0 Mio" },
+              "10000000"        => { "one" => "00 Mio",  "other" => "00 Mio" },
+              "100000000"       => { "one" => "000 Mio", "other" => "000 Mio" },
+              "1000000000"      => { "one" => "0 Mrd",   "other" => "0 Mrd" },
+              "10000000000"     => { "one" => "00 Mrd",  "other" => "00 Mrd" },
+              "100000000000"    => { "one" => "000 Mrd", "other" => "000 Mrd" },
+              "1000000000000"   => { "one" => "0 Bio",   "other" => "0 Bio" },
+              "10000000000000"  => { "one" => "00 Bio",  "other" => "00 Bio" },
+              "100000000000000" => { "one" => "000 Bio", "other" => "000 Bio" }
+            }
         }
       },
       :scientific => {

--- a/test/export_test.rb
+++ b/test/export_test.rb
@@ -54,6 +54,16 @@ class TestExtract < Test::Unit::TestCase
     assert_equal yaml, Cldr::Export::Yaml.new.emit(data)
   end
 
+  test "#locales does not fall back to English (unless the locale is English based)" do
+    assert_equal [:ko, :root], Cldr::Export.locales('ko', 'numbers', :merge => true)
+    assert_equal [:'pt-br', :pt, :root], Cldr::Export.locales('pt-br', 'numbers', :merge => true)
+    assert_equal [:'en-gb', :en, :root], Cldr::Export.locales('en-gb', 'numbers', :merge => true)
+  end
+
+  test "#locales does not fall back if :merge option is false" do
+    assert_equal [:'pt-br', :root], Cldr::Export.locales('pt-br', 'numbers', :merge => false)
+  end
+
   # Cldr::Export::Data.locales.each do |locale|
   #   Cldr::Export::Data.components.each do |component|
   #     test "exported yaml file yaml for #{locale}/#{component} readable" do


### PR DESCRIPTION
Currently ruby-cldr exports only one of the plural forms for each decimal format pattern. That makes it impossible to properly format numbers in languages like Russian where nouns might have multiple plural forms. See twitter/twitter-cldr-rb#129 for a more detailed explanation.

Unfortunately this change isn't backward compatible. Not sure how you do versioning for ruby-cldr, but this change might require a new major (or at least minor) version. 