### PR TITLE
Support for likely subtags (and more)

### DIFF
--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -20,6 +20,10 @@ module Cldr
       SegmentsRoot
       TerritoriesContainment
       WindowsZones
+      LikelySubtags
+      Variables
+      Aliases
+      RegionCurrencies
     ]
 
     class << self

--- a/lib/cldr/export/data.rb
+++ b/lib/cldr/export/data.rb
@@ -3,6 +3,7 @@ require 'core_ext/string/camelize'
 module Cldr
   module Export
     module Data
+      autoload :Aliases,                   'cldr/export/data/aliases'
       autoload :Base,                      'cldr/export/data/base'
       autoload :Calendars,                 'cldr/export/data/calendars'
       autoload :Currencies,                'cldr/export/data/currencies'
@@ -10,6 +11,7 @@ module Cldr
       autoload :Delimiters,                'cldr/export/data/delimiters'
       autoload :Languages,                 'cldr/export/data/languages'
       autoload :Layout,                    'cldr/export/data/layout'
+      autoload :LikelySubtags,             'cldr/export/data/likely_subtags'
       autoload :Lists,                     'cldr/export/data/lists'
       autoload :Metazones,                 'cldr/export/data/metazones'
       autoload :NumberingSystems,          'cldr/export/data/numbering_systems'
@@ -17,18 +19,20 @@ module Cldr
       autoload :Plurals,                   'cldr/export/data/plurals'
       autoload :Rbnf,                      'cldr/export/data/rbnf'
       autoload :RbnfRoot,                  'cldr/export/data/rbnf_root'
+      autoload :RegionCurrencies,          'cldr/export/data/region_currencies'
       autoload :SegmentsRoot,              'cldr/export/data/segments_root'
       autoload :Territories,               'cldr/export/data/territories'
       autoload :TerritoriesContainment,    'cldr/export/data/territories_containment'
       autoload :Timezones,                 'cldr/export/data/timezones'
       autoload :Units,                     'cldr/export/data/units'
+      autoload :Variables,                 'cldr/export/data/variables'
       autoload :WindowsZones,              'cldr/export/data/windows_zones'
 
       class << self
         def dir
           @dir ||= File.expand_path('./vendor/cldr/common')
         end
-      
+
         def dir=(dir)
           @dir = dir
         end

--- a/lib/cldr/export/data/aliases.rb
+++ b/lib/cldr/export/data/aliases.rb
@@ -1,0 +1,47 @@
+module Cldr
+  module Export
+    module Data
+      class Aliases < Base
+
+        # only these aliases will be exported
+        ALIAS_TAGS = %w(languageAlias territoryAlias)
+
+        def initialize
+          super(nil)
+          update(:aliases => aliases)
+        end
+
+        private
+
+        def aliases
+          ALIAS_TAGS.inject({}) do |ret, alias_tag|
+            ret[alias_tag.sub('Alias', '')] = alias_for(alias_tag)
+            ret
+          end
+        end
+
+        def alias_for(alias_tag)
+          doc.xpath("//alias/#{alias_tag}").inject({}) do |ret, alias_data|
+            if replacement_attr = alias_data.attribute('replacement')
+              replacement = replacement_attr.value
+
+              if replacement.include?(' ')
+                replacement = replacement.split(' ')
+              end
+
+              type = alias_data.attribute('type').value
+              ret[type] = replacement
+            end
+
+            ret
+          end
+        end
+
+        def path
+          @path ||= "#{Cldr::Export::Data.dir}/supplemental/supplementalMetadata.xml"
+        end
+
+      end
+    end
+  end
+end

--- a/lib/cldr/export/data/likely_subtags.rb
+++ b/lib/cldr/export/data/likely_subtags.rb
@@ -1,0 +1,29 @@
+module Cldr
+  module Export
+    module Data
+      class LikelySubtags < Base
+
+        def initialize
+          super(nil)
+          update(:subtags => subtags)
+        end
+
+        private
+
+        def subtags
+          doc.xpath('//likelySubtag').inject({}) do |ret, subtag|
+            from = subtag.attribute('from').value
+            to = subtag.attribute('to').value
+            ret[from] = to
+            ret
+          end
+        end
+
+        def path
+          @path ||= "#{Cldr::Export::Data.dir}/supplemental/likelySubtags.xml"
+        end
+
+      end
+    end
+  end
+end

--- a/lib/cldr/export/data/rbnf.rb
+++ b/lib/cldr/export/data/rbnf.rb
@@ -30,13 +30,13 @@ module Cldr
             :type => ruleset_node.attribute("type").value,
             :rules => (ruleset_node / "rbnfrule").map do |rule_node|
               radix = if radix_attr = rule_node.attribute("radix")
-                radix_attr.value
+                cast_value(radix_attr.value)
               else
                 nil
               end
-              
+
               attrs = {
-                :value => rule_node.attribute("value").value,
+                :value => cast_value(rule_node.attribute("value").value),
                 :rule => fix_rule(rule_node.text)
               }
 
@@ -48,6 +48,14 @@ module Cldr
           access = ruleset_node.attribute("access")
           attrs[:access] = access.value if access
           attrs
+        end
+
+        def cast_value(val)
+          if val =~ /\A[\d]+\z/
+            val.to_i
+          else
+            val
+          end
         end
 
         def fix_rule(rule)

--- a/lib/cldr/export/data/region_currencies.rb
+++ b/lib/cldr/export/data/region_currencies.rb
@@ -1,0 +1,45 @@
+module Cldr
+  module Export
+    module Data
+      class RegionCurrencies < Base
+
+        def initialize
+          super(nil)
+          update(:region_currencies => currencies)
+        end
+
+        private
+
+        def currencies
+          doc.xpath('//currencyData/region').inject({}) do |ret, region|
+            name = region.attribute('iso3166').value
+            ret[name] = currency(region)
+            ret
+          end
+        end
+
+        def currency(node)
+          (node / 'currency').map do |currency|
+            currency_code = currency.attribute('iso4217').value
+            result = { currency: currency_code }
+
+            if from_node = currency.attribute('from')
+              result[:from] = from_node.value
+            end
+
+            if to_node = currency.attribute('to')
+              result[:to] = to_node.value
+            end
+
+            result
+          end
+        end
+
+        def path
+          @path ||= "#{Cldr::Export::Data.dir}/supplemental/supplementalData.xml"
+        end
+
+      end
+    end
+  end
+end

--- a/lib/cldr/export/data/segments_root.rb
+++ b/lib/cldr/export/data/segments_root.rb
@@ -26,7 +26,7 @@ module Cldr
         def variables(node)
           (node / "variables" / "variable").map do |variable|
             {
-              :id => variable.attribute("id").value,
+              :id => cast_value(variable.attribute("id").value),
               :value => variable.text
             }
           end
@@ -35,7 +35,7 @@ module Cldr
         def rules(node)
           (node / "segmentRules" / "rule").map do |rule|
             {
-              :id => rule.attribute("id").value,
+              :id => cast_value(rule.attribute("id").value),
               :value => rule.text
             }
           end
@@ -43,6 +43,16 @@ module Cldr
 
         def path
           @path ||= "#{Cldr::Export::Data.dir}/segments/root.xml"
+        end
+
+        def cast_value(value)
+          if value =~ /\A[\d]+\z/
+            value.to_i
+          elsif value =~ /\A[\d.]+\z/
+            value.to_f
+          else
+            value
+          end
         end
 
       end

--- a/lib/cldr/export/data/variables.rb
+++ b/lib/cldr/export/data/variables.rb
@@ -4,7 +4,7 @@ module Cldr
       class Variables < Base
 
         # only these variables will be exported
-        VARIABLE_IDS = %w($grandfathered)
+        VARIABLE_IDS = %w($grandfathered $language $territory $script $variant)
 
         def initialize
           super(nil)

--- a/lib/cldr/export/data/variables.rb
+++ b/lib/cldr/export/data/variables.rb
@@ -1,0 +1,42 @@
+module Cldr
+  module Export
+    module Data
+      class Variables < Base
+
+        # only these variables will be exported
+        VARIABLE_IDS = %w($grandfathered)
+
+        def initialize
+          super(nil)
+          update(:variables => variables)
+        end
+
+        private
+
+        def variables
+          doc.xpath('//validity/variable').inject({}) do |ret, variable|
+            name = variable.attribute('id').value
+            if VARIABLE_IDS.include?(name)
+              ret[fix_var_name(name)] = split_value_list(variable.text)
+            end
+            ret
+          end
+        end
+
+        def fix_var_name(var_name)
+          # remove leading dollar sign
+          var_name.sub(/\A\$/, '')
+        end
+
+        def split_value_list(value_list)
+          value_list.strip.split(/[\s]+/)
+        end
+
+        def path
+          @path ||= "#{Cldr::Export::Data.dir}/supplemental/supplementalMetadata.xml"
+        end
+
+      end
+    end
+  end
+end

--- a/lib/cldr/export/yaml.rb
+++ b/lib/cldr/export/yaml.rb
@@ -29,12 +29,7 @@ module Cldr
       end
 
       def is_one_plain_line?(str)
-        # removed REX_BOOL, REX_INT
-        str !~ /^([\-\?:,\[\]\{\}\#&\*!\|>'"%@`\s]|---|\.\.\.)/ &&
-          str !~ /[:\#\s\[\]\{\},]/ &&
-          str !~ /#{REX_ANY_LB}/ &&
-          str !~ /^0[0-7]+$/ &&
-          str !~ /^(#{REX_FLOAT}|#{REX_MERGE}|#{REX_NULL}|#{REX_TIMESTAMP}|#{REX_VALUE})$/x
+        false  # always quote, always dump symbols even if they are numbers
       end
     end
   end


### PR DESCRIPTION
Adding support for:

* likely subtags
* language and territory aliases
* variables (for $grandfathered locale codes)
* currencies by region

Includes @KL-7's `kl_nubmber_patttern_pluralization` branch, i.e. #33.

Finally, includes a change to YAML dumping that fixes issues trying to dump symbols and numbers. I was seeing some numeric-ish symbol values (eg. :"001") getting dumped as strings, and some other numeric values getting dumped as number literals even though they were symbols.