### PR TITLE
Add support for parentLocales

### DIFF
--- a/lib/cldr/export/data.rb
+++ b/lib/cldr/export/data.rb
@@ -18,6 +18,7 @@ module Cldr
       autoload :Metazones,                 'cldr/export/data/metazones'
       autoload :NumberingSystems,          'cldr/export/data/numbering_systems'
       autoload :Numbers,                   'cldr/export/data/numbers'
+      autoload :ParentLocales,             'cldr/export/data/parent_locales'
       autoload :Plurals,                   'cldr/export/data/plurals'
       autoload :PluralRules,               'cldr/export/data/plural_rules'
       autoload :Rbnf,                      'cldr/export/data/rbnf'

--- a/lib/cldr/export/data/parent_locales.rb
+++ b/lib/cldr/export/data/parent_locales.rb
@@ -1,0 +1,23 @@
+require 'nokogiri'
+
+module Cldr
+  module Export
+    module Data
+      class ParentLocales < Hash
+        def initialize
+          path = File.join(Cldr::Export::Data.dir, 'supplemental', 'supplementalData.xml')
+          doc = File.open(path) { |file| Nokogiri::XML(file) }
+
+          doc.xpath('//parentLocales/parentLocale').each do |node|
+            parent = node.attr('parent')
+            locales = node.attr('locales').split(' ')
+
+            locales.each do |locale|
+              self[locale] = parent
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/export_test.rb
+++ b/test/export_test.rb
@@ -26,6 +26,11 @@ class TestExtract < Test::Unit::TestCase
     assert_equal 'NaN', data[:numbers][:symbols][:nan]
   end
 
+  test 'the merge option respects parentLocales' do
+    data = Cldr::Export.data('calendars', 'en-GB', :merge => true)
+    assert_equal 'dd/MM/y', data[:calendars][:gregorian][:additional_formats]['yMd']
+  end
+
   test "exports data to files" do
     Cldr::Export.export(:locales => %w(de), :components => %w(calendars))
     assert File.exists?(Cldr::Export.path('de', 'calendars', 'yml'))


### PR DESCRIPTION
Use the parentLocales section to figure out the correct fallback
locales.  Can not use customization feature of I18n::Locale::Fallbacks
since it always places the default parent local before any customizations.