### PR TITLE
Automatically remove empty transforms

### DIFF
--- a/lib/cldr/export/data/transforms.rb
+++ b/lib/cldr/export/data/transforms.rb
@@ -34,11 +34,15 @@ module Cldr
         end
 
         def rules(transform_node)
-          fix_rule_wrapping(
-            doc.xpath("#{transform_node.path}/tRule").map do |rule_node|
-              fix_rule(rule_node.content)
+          rules = fix_rule_wrapping(
+            doc.xpath("#{transform_node.path}/tRule").flat_map do |rule_node|
+              fix_rule(rule_node.content).split("\n").map(&:strip)
             end
           )
+
+          rules.reject do |rule|
+            rule.strip.empty? || rule.strip.start_with?('#')
+          end
         end
 
         def fix_rule_wrapping(rules)


### PR DESCRIPTION
Kind of a minor thing, just removes empty lines and comments from the list of transform rules.

@tigrish 