### PR TITLE
Don't merge root language when merge option is false

### DIFF
--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -143,12 +143,12 @@ module Cldr
             end
           end
 
-          ancestry
+          ancestry << :root if component_should_merge_root?(component)
+          ancestry 
         else
           [locale]
         end
 
-        locales << :root if component_should_merge_root?(component)
         locales
       end
 

--- a/test/export_test.rb
+++ b/test/export_test.rb
@@ -66,7 +66,7 @@ class TestExtract < Test::Unit::TestCase
   end
 
   test "#locales does not fall back if :merge option is false" do
-    assert_equal [:'pt-br', :root], Cldr::Export.locales('pt-br', 'numbers', :merge => false)
+    assert_equal [:'pt-br'], Cldr::Export.locales('pt-br', 'numbers', :merge => false)
   end
 
   # Cldr::Export::Data.locales.each do |locale|


### PR DESCRIPTION
Currently even when merge is false, root is still merged. This causes files that should inherits from parent (like `fr-FR/numbers` for example, to be a copy of `root/numbers` instead of being empty.